### PR TITLE
Add Edge history manager extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# timeMachine
+# Time Machine
+
+This repository contains a Microsoft Edge extension that provides advanced history management.
+
+## Features
+- Search history by text or site with `*` wildcards
+- Filter by start and end dates
+- Delete all results or select individual entries (with shift-click multi-select)
+
+## Usage
+1. Open `edge://extensions` in Edge and enable **Developer mode**.
+2. Click **Load unpacked** and choose the `edge-history-extension` folder.
+3. Click the extension's toolbar button to open the manager window.
+
+## Development
+The extension source lives in `edge-history-extension/`.
+Currently there are no automated tests.

--- a/edge-history-extension/background.js
+++ b/edge-history-extension/background.js
@@ -1,0 +1,8 @@
+chrome.action.onClicked.addListener(() => {
+  chrome.windows.create({
+    url: chrome.runtime.getURL('history.html'),
+    type: 'popup',
+    width: 800,
+    height: 600
+  });
+});

--- a/edge-history-extension/history.css
+++ b/edge-history-extension/history.css
@@ -1,0 +1,6 @@
+body { font-family: Arial, sans-serif; margin: 10px; }
+#filters input { margin-right: 5px; }
+#actions { margin-top: 10px; }
+#results { width: 100%; border-collapse: collapse; margin-top: 10px; }
+#results th, #results td { border: 1px solid #ddd; padding: 4px; }
+#results th { background-color: #f2f2f2; }

--- a/edge-history-extension/history.html
+++ b/edge-history-extension/history.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Time Machine History Manager</title>
+  <link rel="stylesheet" href="history.css">
+</head>
+<body>
+  <h1>History Manager</h1>
+  <div id="filters">
+    <input type="text" id="searchText" placeholder="Search text or URL (* wildcard)">
+    <input type="date" id="startDate">
+    <input type="date" id="endDate">
+    <button id="searchBtn">Search</button>
+  </div>
+  <div id="actions">
+    <button id="deleteSelected">Delete Selected</button>
+    <button id="deleteAll">Delete All</button>
+  </div>
+  <table id="results">
+    <thead>
+      <tr><th></th><th>Title</th><th>URL</th><th>Last Visit</th></tr>
+    </thead>
+    <tbody id="resultsBody"></tbody>
+  </table>
+  <script src="history.js"></script>
+</body>
+</html>

--- a/edge-history-extension/history.js
+++ b/edge-history-extension/history.js
@@ -1,0 +1,102 @@
+const resultsBody = document.getElementById('resultsBody');
+const searchBtn = document.getElementById('searchBtn');
+const deleteSelectedBtn = document.getElementById('deleteSelected');
+const deleteAllBtn = document.getElementById('deleteAll');
+let currentResults = [];
+let lastChecked = null;
+
+function escapeRegExp(str) {
+  return str.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+}
+
+function wildcardToRegExp(pattern) {
+  const escaped = escapeRegExp(pattern);
+  return new RegExp('^' + escaped.split('*').join('.*') + '$', 'i');
+}
+
+function addShiftClick(checkbox) {
+  checkbox.addEventListener('click', (e) => {
+    if (!lastChecked) {
+      lastChecked = checkbox;
+      return;
+    }
+    if (e.shiftKey) {
+      const boxes = Array.from(document.querySelectorAll('.history-checkbox'));
+      let start = boxes.indexOf(checkbox);
+      let end = boxes.indexOf(lastChecked);
+      if (start > end) [start, end] = [end, start];
+      for (let i = start; i <= end; i++) {
+        boxes[i].checked = lastChecked.checked;
+      }
+    }
+    lastChecked = checkbox;
+  });
+}
+
+function renderResults() {
+  resultsBody.innerHTML = '';
+  currentResults.forEach(item => {
+    const tr = document.createElement('tr');
+    const tdCheck = document.createElement('td');
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.className = 'history-checkbox';
+    cb.dataset.url = item.url;
+    addShiftClick(cb);
+    tdCheck.appendChild(cb);
+    tr.appendChild(tdCheck);
+
+    const tdTitle = document.createElement('td');
+    tdTitle.textContent = item.title || item.url;
+    tr.appendChild(tdTitle);
+
+    const tdUrl = document.createElement('td');
+    tdUrl.textContent = item.url;
+    tr.appendChild(tdUrl);
+
+    const tdTime = document.createElement('td');
+    tdTime.textContent = new Date(item.lastVisitTime).toLocaleString();
+    tr.appendChild(tdTime);
+
+    resultsBody.appendChild(tr);
+  });
+}
+
+function searchHistory() {
+  const text = document.getElementById('searchText').value.trim();
+  const startDate = document.getElementById('startDate').value;
+  const endDate = document.getElementById('endDate').value;
+
+  const query = { text: '', maxResults: 10000 };
+  if (startDate) query.startTime = new Date(startDate).getTime();
+  if (endDate) query.endTime = new Date(endDate).getTime();
+
+  chrome.history.search(query, (items) => {
+    let pattern = null;
+    if (text) pattern = wildcardToRegExp(text);
+    currentResults = items.filter(item => {
+      if (!pattern) return true;
+      return pattern.test(item.title || '') || pattern.test(item.url);
+    });
+    renderResults();
+  });
+}
+
+function getSelected() {
+  return Array.from(document.querySelectorAll('.history-checkbox:checked')).map(cb => cb.dataset.url);
+}
+
+function deleteSelected() {
+  const urls = getSelected();
+  urls.forEach(url => chrome.history.deleteUrl({ url }));
+  searchHistory();
+}
+
+function deleteAll() {
+  currentResults.forEach(item => chrome.history.deleteUrl({ url: item.url }));
+  searchHistory();
+}
+
+searchBtn.addEventListener('click', searchHistory);
+deleteSelectedBtn.addEventListener('click', deleteSelected);
+deleteAllBtn.addEventListener('click', deleteAll);

--- a/edge-history-extension/manifest.json
+++ b/edge-history-extension/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Time Machine History Manager",
+  "description": "Search and mass delete browser history by date, site, or text.",
+  "version": "1.0.0",
+  "permissions": ["history"],
+  "action": {
+    "default_title": "Time Machine"
+  },
+  "background": {
+    "service_worker": "background.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add Edge extension for bulk history search and delete
- document features and loading steps

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb8d2328483328d8ed5579e3e45cd